### PR TITLE
Assert alignment in get_type()

### DIFF
--- a/runtime/src/tiered_storage/mmap_utils.rs
+++ b/runtime/src/tiered_storage/mmap_utils.rs
@@ -7,6 +7,7 @@ use {
 pub fn get_type<T>(map: &Mmap, offset: usize) -> std::io::Result<(&T, usize)> {
     let (data, next) = get_slice(map, offset, std::mem::size_of::<T>())?;
     let ptr = data.as_ptr() as *const T;
+    debug_assert!(ptr as usize % std::mem::align_of::<T>() == 0);
     Ok((unsafe { &*ptr }, next))
 }
 


### PR DESCRIPTION
#### Problem

`get_type()` doesn't ensure alignment.

#### Summary of Changes

Add a `debug_assert!` to make sure we get alignment correct.
